### PR TITLE
StreamUtils: swap parameter order from max/min to min/max

### DIFF
--- a/core/src/main/java/org/veriblock/sdk/Coin.java
+++ b/core/src/main/java/org/veriblock/sdk/Coin.java
@@ -72,7 +72,7 @@ public final strictfp class Coin implements Comparable<Coin> {
     }
 
     public static Coin parse(ByteBuffer txBuffer) {
-        long atomicUnits = Utils.toLong(StreamUtils.getSingleByteLengthValue(txBuffer, 8, 0));
+        long atomicUnits = Utils.toLong(StreamUtils.getSingleByteLengthValue(txBuffer, 0, 8));
         return Coin.valueOf(atomicUnits);
     }
 }

--- a/core/src/main/java/org/veriblock/sdk/services/SerializeDeserializeService.java
+++ b/core/src/main/java/org/veriblock/sdk/services/SerializeDeserializeService.java
@@ -95,8 +95,8 @@ public class SerializeDeserializeService {
 
 
     public static VeriBlockPoPTransaction parseVeriBlockPoPTx(ByteBuffer buffer) {
-        byte[] rawTx = StreamUtils.getVariableLengthValue(buffer, MAX_RAWTX_SIZE_VeriBlockPoPTransaction, 0);
-        byte[] signature = StreamUtils.getSingleByteLengthValue(buffer, Constants.MAX_SIGNATURE_SIZE, 0);
+        byte[] rawTx = StreamUtils.getVariableLengthValue(buffer, 0, MAX_RAWTX_SIZE_VeriBlockPoPTransaction);
+        byte[] signature = StreamUtils.getSingleByteLengthValue(buffer, 0, Constants.MAX_SIGNATURE_SIZE);
         byte[] publicKey = StreamUtils.getSingleByteLengthValue(buffer, Constants.PUBLIC_KEY_SIZE, Constants.PUBLIC_KEY_SIZE);
 
         ByteBuffer txBuffer = ByteBuffer.wrap(rawTx);
@@ -116,7 +116,7 @@ public class SerializeDeserializeService {
         MerklePath merklePath = parseMerklePath(txBuffer, Sha256Hash.twiceOf(bitcoinTransaction.getRawBytes()));
         BitcoinBlock blockOfProof = parseBitcoinBlockWithLength(txBuffer);
 
-        int contextCount = Utils.toInt(StreamUtils.getSingleByteLengthValue(txBuffer, Constants.MAX_CONTEXT_COUNT, 0));
+        int contextCount = Utils.toInt(StreamUtils.getSingleByteLengthValue(txBuffer, 0, Constants.MAX_CONTEXT_COUNT));
         if (contextCount < 0 || contextCount > Constants.MAX_CONTEXT_COUNT) {
             throw new IllegalArgumentException("Unexpected context count: " + contextCount
                     + " (expected a value between 0 and " + Constants.MAX_CONTEXT_COUNT + ")");
@@ -208,7 +208,7 @@ public class SerializeDeserializeService {
         VeriBlockMerklePath merklePath = parseVeriBlockMerklePath(buffer);
         VeriBlockBlock containingBlock = parseVeriBlockBlock(buffer);
 
-        int contextCount = Utils.toInt(StreamUtils.getSingleByteLengthValue(buffer, 4, 0));
+        int contextCount = Utils.toInt(StreamUtils.getSingleByteLengthValue(buffer, 0, 4));
 
         if (contextCount < 0 || contextCount > Constants.MAX_CONTEXT_COUNT) {
             throw new IllegalArgumentException("Unexpected context count: " + contextCount
@@ -255,8 +255,8 @@ public class SerializeDeserializeService {
 //VeriBlockTransaction
 
     public static VeriBlockTransaction parseVeriBlockTransaction(ByteBuffer buffer) {
-        byte[] rawTx = StreamUtils.getVariableLengthValue(buffer, MAX_RAWTX_SIZE_VeriBlockTransaction, 0);
-        byte[] signature = StreamUtils.getSingleByteLengthValue(buffer, Constants.MAX_SIGNATURE_SIZE, 0);
+        byte[] rawTx = StreamUtils.getVariableLengthValue(buffer, 0, MAX_RAWTX_SIZE_VeriBlockTransaction);
+        byte[] signature = StreamUtils.getSingleByteLengthValue(buffer, 0, Constants.MAX_SIGNATURE_SIZE);
         byte[] publicKey = StreamUtils.getSingleByteLengthValue(buffer, Constants.PUBLIC_KEY_SIZE, Constants.PUBLIC_KEY_SIZE);
 
         ByteBuffer txBuffer = ByteBuffer.wrap(rawTx);
@@ -287,8 +287,8 @@ public class SerializeDeserializeService {
             outputs.add(SerializeDeserializeService.parseOutput(txBuffer));
         }
 
-        long signatureIndex = Utils.toLong(StreamUtils.getSingleByteLengthValue(txBuffer, 8, 0));
-        byte[] data = StreamUtils.getVariableLengthValue(txBuffer, MAX_SIZE_PUBLICATION_DATA, 0);
+        long signatureIndex = Utils.toLong(StreamUtils.getSingleByteLengthValue(txBuffer, 0, 8));
+        byte[] data = StreamUtils.getVariableLengthValue(txBuffer, 0, MAX_SIZE_PUBLICATION_DATA);
 
         return new VeriBlockTransaction(typeId, sourceAddress, sourceAmount, outputs,
                 signatureIndex, data, signature, publicKey, networkByte);
@@ -424,7 +424,7 @@ public class SerializeDeserializeService {
     // Unfortunately, the serialized MerklePath coming from NodeCore does not contain
     // the subject data, so it must be supplied.
     public static MerklePath parseMerklePath(ByteBuffer buffer, Sha256Hash subject) {
-        byte[] merkleBytes = StreamUtils.getVariableLengthValue(buffer, Constants.MAX_MERKLE_BYTES, 0);
+        byte[] merkleBytes = StreamUtils.getVariableLengthValue(buffer, 0, Constants.MAX_MERKLE_BYTES);
         ByteBuffer localBuffer = ByteBuffer.wrap(merkleBytes);
 
         int index = StreamUtils.getSingleIntValue(localBuffer);
@@ -637,7 +637,7 @@ public class SerializeDeserializeService {
 
     public static Address parseAddress(ByteBuffer buffer) {
         int addressType = buffer.get();
-        byte[] addressBytes = StreamUtils.getSingleByteLengthValue(buffer, Constants.SIZE_ADDRESS, 0);
+        byte[] addressBytes = StreamUtils.getSingleByteLengthValue(buffer, 0, Constants.SIZE_ADDRESS);
         if (addressType == 1) {
             return new Address(Base58.encode(addressBytes));
         } else {
@@ -714,7 +714,7 @@ public class SerializeDeserializeService {
         VeriBlockMerklePath merklePath = parseVeriBlockMerklePath(buffer);
         VeriBlockBlock containingBlock = parseVeriBlockBlock(buffer);
 
-        int contextCount = Utils.toInt(StreamUtils.getSingleByteLengthValue(buffer, 4, 0));
+        int contextCount = Utils.toInt(StreamUtils.getSingleByteLengthValue(buffer, 0, 4));
 
         if (contextCount < 0 || contextCount > Constants.MAX_CONTEXT_COUNT_ALT_PUBLICATION) {
             throw new IllegalArgumentException("Unexpected context count: " + contextCount
@@ -752,11 +752,11 @@ public class SerializeDeserializeService {
         if (data == null || data.length == 0) return null;
 
         ByteBuffer buffer = ByteBuffer.wrap(data);
-        byte[] identifierBytes = StreamUtils.getSingleByteLengthValue(buffer, 8, 0);
+        byte[] identifierBytes = StreamUtils.getSingleByteLengthValue(buffer, 0, 8);
         long identifier = Utils.toLong(identifierBytes);
-        byte[] headerBytes = StreamUtils.getVariableLengthValue(buffer, Constants.MAX_HEADER_SIZE_PUBLICATION_DATA, 0);
-        byte[] contextInfoBytes = StreamUtils.getVariableLengthValue(buffer, Constants.MAX_PAYOUT_SIZE_PUBLICATION_DATA, 0);
-        byte[] payoutInfoBytes = StreamUtils.getVariableLengthValue(buffer, Constants.MAX_CONTEXT_SIZE_PUBLICATION_DATA, 0);
+        byte[] headerBytes = StreamUtils.getVariableLengthValue(buffer, 0, Constants.MAX_HEADER_SIZE_PUBLICATION_DATA);
+        byte[] contextInfoBytes = StreamUtils.getVariableLengthValue(buffer, 0, Constants.MAX_PAYOUT_SIZE_PUBLICATION_DATA);
+        byte[] payoutInfoBytes = StreamUtils.getVariableLengthValue(buffer, 0, Constants.MAX_CONTEXT_SIZE_PUBLICATION_DATA);
 
         return new PublicationData(identifier, headerBytes, payoutInfoBytes, contextInfoBytes);
     }
@@ -777,7 +777,7 @@ public class SerializeDeserializeService {
     }
 
     public static BitcoinTransaction parseBitcoinTransaction(ByteBuffer buffer) {
-        byte[] raw = StreamUtils.getVariableLengthValue(buffer, Constants.MAX_RAWTX_SIZE, 0);
+        byte[] raw = StreamUtils.getVariableLengthValue(buffer, 0, Constants.MAX_RAWTX_SIZE);
         return new BitcoinTransaction(raw);
     }
 }

--- a/core/src/main/java/org/veriblock/sdk/util/StreamUtils.java
+++ b/core/src/main/java/org/veriblock/sdk/util/StreamUtils.java
@@ -43,9 +43,9 @@ public class StreamUtils {
     }
     
 
-    public static byte[] getSingleByteLengthValue(ByteBuffer buffer, int maxLength, int minLength) {
+    public static byte[] getSingleByteLengthValue(ByteBuffer buffer, int minLength, int maxLength) {
         int length = buffer.get();
-        checkLength(length, maxLength, minLength);
+        checkLength(length, minLength, maxLength);
         
         byte[] value = new byte[length];
         buffer.get(value);
@@ -54,22 +54,22 @@ public class StreamUtils {
     }
     
     public static byte[] getSingleByteLengthValue(ByteBuffer buffer) {
-        return getSingleByteLengthValue(buffer, 255, 0);
+        return getSingleByteLengthValue(buffer, 0, 255);
     }
     
     public static int getSingleIntValue(ByteBuffer buffer) {
         return Utils.toInt(getSingleByteLengthValue(buffer, 4, 4));
     }
 
-    public static byte[] getVariableLengthValue(ByteBuffer buffer, int maxLength, int minLength) {
+    public static byte[] getVariableLengthValue(ByteBuffer buffer, int minLength, int maxLength) {
         byte lengthLength = buffer.get();
-        checkLength(lengthLength, 4, 0);
+        checkLength(lengthLength, 0, 4);
         
         byte[] lengthBytes = new byte[4];
         buffer.get(lengthBytes, 4 - lengthLength, lengthLength);
 
         int length = ByteBuffer.wrap(lengthBytes).getInt();
-        checkLength(length, maxLength, minLength);
+        checkLength(length, minLength, maxLength);
         
         byte[] value = new byte[length];
         buffer.get(value);
@@ -78,10 +78,10 @@ public class StreamUtils {
     }
     
     public static byte[] getVariableLengthValue(ByteBuffer buffer) {  
-        return getVariableLengthValue(buffer, Integer.MAX_VALUE, 0);
+        return getVariableLengthValue(buffer, 0, Integer.MAX_VALUE);
     }
     
-    private static void checkLength(int length, int maxLength, int minLength)
+    private static void checkLength(int length, int minLength, int maxLength)
     {
         if (length < minLength || length > maxLength)
             throw new IllegalArgumentException("Unexpected length: " + length


### PR DESCRIPTION
Specifying min first feels more intuitive to me however if there's a convention or standard I'm unaware of specifying max first, so be it