### PR TITLE
Fix wrong package for new files from PR-10

### DIFF
--- a/reference-lib/src/test/java/org/veriblock/integrations/blockchain/store/PoPTransactionsDBStoreTest.java
+++ b/reference-lib/src/test/java/org/veriblock/integrations/blockchain/store/PoPTransactionsDBStoreTest.java
@@ -8,23 +8,37 @@
 
 package org.veriblock.integrations.blockchain.store;
 
+import java.nio.file.Paths;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.veriblock.integrations.blockchain.store.PoPTransactionsDBStore;
 import org.veriblock.integrations.sqlite.ConnectionSelector;
 import org.veriblock.integrations.sqlite.FileManager;
 import org.veriblock.integrations.sqlite.tables.PoPTransactionData;
-import org.veriblock.sdk.*;
+import org.veriblock.sdk.Address;
+import org.veriblock.sdk.AltChainBlock;
+import org.veriblock.sdk.AltPublication;
+import org.veriblock.sdk.BitcoinTransaction;
+import org.veriblock.sdk.Coin;
+import org.veriblock.sdk.MerklePath;
+import org.veriblock.sdk.PublicationData;
+import org.veriblock.sdk.Sha256Hash;
+import org.veriblock.sdk.VBlakeHash;
+import org.veriblock.sdk.VeriBlockBlock;
+import org.veriblock.sdk.VeriBlockMerklePath;
+import org.veriblock.sdk.VeriBlockPoPTransaction;
+import org.veriblock.sdk.VeriBlockPublication;
+import org.veriblock.sdk.VeriBlockTransaction;
 import org.veriblock.sdk.services.SerializeDeserializeService;
 import org.veriblock.sdk.util.Utils;
-
-import java.nio.file.Paths;
-import java.rmi.ServerError;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.*;
 
 public class PoPTransactionsDBStoreTest {
 

--- a/reference-lib/src/test/java/org/veriblock/integrations/rewards/VeriBlockRewardCalculatorTest.java
+++ b/reference-lib/src/test/java/org/veriblock/integrations/rewards/VeriBlockRewardCalculatorTest.java
@@ -31,7 +31,6 @@ import org.veriblock.integrations.sqlite.ConnectionSelector;
 import org.veriblock.integrations.sqlite.FileManager;
 import org.veriblock.integrations.sqlite.tables.PoPTransactionData;
 import org.veriblock.sdk.*;
-import org.veriblock.sdk.services.SerializeDeserializeService;
 import org.veriblock.sdk.util.Utils;
 
 public class VeriBlockRewardCalculatorTest {
@@ -406,8 +405,6 @@ public class VeriBlockRewardCalculatorTest {
         
         long reward1 = 0;
         long reward2 = 0;
-        long reward3 = 0;
-        long reward4 = 0;
 
         AltPublication altPublication1;
         AltPublication altPublication2;
@@ -525,7 +522,6 @@ public class VeriBlockRewardCalculatorTest {
         // assert that two endorsements from the block 31 get the same reward
         Assert.assertEquals(rewards.get(3), rewards.get(2));
         // assert that endorsement from the block 30 get higher reward than from the block 31
-        int result = rewards.get(0).compareTo(rewards.get(3));
         Assert.assertEquals(rewards.get(0).compareTo(rewards.get(3)), -1);
         
         BigDecimal scoreTotal = PopRewardCalculator.calculatePopScoreFromEndorsements(endorsedBlock, endorsementBlocks);

--- a/reference-lib/src/test/java/org/veriblock/integrations/sqlite/SqliteBitcoinBlocksTableTest.java
+++ b/reference-lib/src/test/java/org/veriblock/integrations/sqlite/SqliteBitcoinBlocksTableTest.java
@@ -25,7 +25,6 @@ import org.veriblock.integrations.sqlite.tables.KeyValueData;
 import org.veriblock.integrations.sqlite.tables.BitcoinBlockRepository;
 import org.veriblock.integrations.sqlite.tables.KeyValueRepository;
 import org.veriblock.sdk.services.SerializeDeserializeService;
-import org.veriblock.sdk.Sha256Hash;
 
 //FIXME: split this into tests of BitcoinBlockRepository and KeyValueRepository
 public class SqliteBitcoinBlocksTableTest {

--- a/reference-lib/src/test/java/org/veriblock/integrations/sqlite/tables/BitcoinBlockRepositoryTest.java
+++ b/reference-lib/src/test/java/org/veriblock/integrations/sqlite/tables/BitcoinBlockRepositoryTest.java
@@ -6,22 +6,21 @@
 // Distributed under the MIT software license, see the accompanying
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
-package org.veriblock.integrations.blockchain.store;
-
-import org.junit.*;
-
-import org.veriblock.integrations.sqlite.ConnectionSelector;
-import org.veriblock.integrations.sqlite.tables.BitcoinBlockRepository;
-import org.veriblock.sdk.services.SerializeDeserializeService;
-import org.veriblock.sdk.Sha256Hash;
-import org.veriblock.sdk.util.Utils;
+package org.veriblock.integrations.sqlite.tables;
 
 import java.io.IOException;
 import java.math.BigInteger;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Base64;
-import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.veriblock.integrations.blockchain.store.StoredBitcoinBlock;
+import org.veriblock.integrations.sqlite.ConnectionSelector;
+import org.veriblock.sdk.services.SerializeDeserializeService;
 
 public class BitcoinBlockRepositoryTest {
     private byte[] rawBlock;

--- a/reference-lib/src/test/java/org/veriblock/integrations/sqlite/tables/VeriBlockBlockRepositoryTest.java
+++ b/reference-lib/src/test/java/org/veriblock/integrations/sqlite/tables/VeriBlockBlockRepositoryTest.java
@@ -6,15 +6,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file LICENSE or http://www.opensource.org/licenses/mit-license.php.
 
-package org.veriblock.integrations.blockchain.store;
-
-import org.junit.*;
-
-import org.veriblock.integrations.sqlite.ConnectionSelector;
-import org.veriblock.integrations.sqlite.tables.VeriBlockBlockRepository;
-import org.veriblock.sdk.services.SerializeDeserializeService;
-import org.veriblock.sdk.Sha256Hash;
-import org.veriblock.sdk.util.Utils;
+package org.veriblock.integrations.sqlite.tables;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -22,6 +14,15 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Base64;
 import java.util.List;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.veriblock.integrations.blockchain.store.StoredVeriBlockBlock;
+import org.veriblock.integrations.sqlite.ConnectionSelector;
+import org.veriblock.sdk.Sha256Hash;
+import org.veriblock.sdk.services.SerializeDeserializeService;
 
 public class VeriBlockBlockRepositoryTest {
     private byte[] rawBlock;


### PR DESCRIPTION
Eclipse does not allow package name different from the source folder. Added a fix so dependent projects can be built.