### PR TITLE
*store: enforce put() / replace() separation: put() must be used only to add new blocks and returns nothing, replace() can be used to add a new block and it is possible to check if the block was new by examining the return value

### DIFF
--- a/core/src/main/java/org/veriblock/sdk/blockchain/store/BitcoinStore.java
+++ b/core/src/main/java/org/veriblock/sdk/blockchain/store/BitcoinStore.java
@@ -79,6 +79,10 @@ public class BitcoinStore implements BlockStore<StoredBitcoinBlock, Sha256Hash> 
     }
 
     public void put(StoredBitcoinBlock storedBlock) throws BlockStoreException, SQLException {
+        if (bitcoinRepository.get(storedBlock.getHash()) != null) {
+            throw new BlockStoreException("A block with the same hash is already in the store");
+        }
+
         bitcoinRepository.save(storedBlock);
     }
     

--- a/core/src/main/java/org/veriblock/sdk/blockchain/store/VeriBlockStore.java
+++ b/core/src/main/java/org/veriblock/sdk/blockchain/store/VeriBlockStore.java
@@ -79,6 +79,10 @@ public class VeriBlockStore implements BlockStore<StoredVeriBlockBlock, VBlakeHa
     }
 
     public void put(StoredVeriBlockBlock storedBlock) throws BlockStoreException, SQLException {
+        if (veriBlockRepository.get(storedBlock.getHash()) != null) {
+            throw new BlockStoreException("A block with the same hash is already in the store");
+        }
+
         veriBlockRepository.save(storedBlock);
     }
 

--- a/core/src/test/java/org/veriblock/sdk/blockchain/store/BitcoinStoreTest.java
+++ b/core/src/test/java/org/veriblock/sdk/blockchain/store/BitcoinStoreTest.java
@@ -94,6 +94,28 @@ public class BitcoinStoreTest {
     }
 
     @Test
+    public void PutDoesNotUpdateTest() throws SQLException, IOException {
+        StoredBitcoinBlock updatedStoredBlock1 = new StoredBitcoinBlock(block1, BigInteger.ONE, 0);
+        Assert.assertNotEquals(updatedStoredBlock1, storedBlock1);
+
+        store.put(storedBlock1);
+
+        try {
+            store.put(storedBlock1);
+            Assert.fail("Should throw BlockStoreException");
+        } catch (BlockStoreException e) {
+            Assert.assertEquals("A block with the same hash is already in the store", e.getMessage());
+        }
+
+        try {
+            store.put(updatedStoredBlock1);
+            Assert.fail("Should throw BlockStoreException");
+        } catch (BlockStoreException e) {
+            Assert.assertEquals("A block with the same hash is already in the store", e.getMessage());
+        }
+    }
+
+    @Test
     public void chainHeadStoreTest() throws SQLException, IOException {
         byte[] raw = Base64.getDecoder().decode("AAAAIPfeKZWJiACrEJr5Z3m5eaYHFdqb8ru3RbMAAAAAAAAA+FSGAmv06tijekKSUzLsi1U/jjEJdP6h66I4987mFl4iE7dchBoBGi4A8po=");
         StoredBitcoinBlock storedBitcoinBlockExpected = new StoredBitcoinBlock(SerializeDeserializeService.parseBitcoinBlock(raw), BigInteger.TEN, 0);

--- a/core/src/test/java/org/veriblock/sdk/blockchain/store/BitcoinStoreTest.java
+++ b/core/src/test/java/org/veriblock/sdk/blockchain/store/BitcoinStoreTest.java
@@ -94,7 +94,7 @@ public class BitcoinStoreTest {
     }
 
     @Test
-    public void PutDoesNotUpdateTest() throws SQLException, IOException {
+    public void putDoesNotUpdateTest() throws SQLException, IOException {
         StoredBitcoinBlock updatedStoredBlock1 = new StoredBitcoinBlock(block1, BigInteger.ONE, 0);
         Assert.assertNotEquals(updatedStoredBlock1, storedBlock1);
 

--- a/core/src/test/java/org/veriblock/sdk/blockchain/store/VeriBlockStoreTest.java
+++ b/core/src/test/java/org/veriblock/sdk/blockchain/store/VeriBlockStoreTest.java
@@ -87,7 +87,28 @@ public class VeriBlockStoreTest {
 
             Assert.assertEquals(storedVeriBlockBlockExpected, storedVeriBlockBlockActual);
     }
-    
+
+    public void PutDoesNotUpdateTest() throws SQLException, IOException {
+        StoredVeriBlockBlock updatedStoredBlock1 = new StoredVeriBlockBlock(block1, BigInteger.ONE);
+        Assert.assertNotEquals(updatedStoredBlock1, storedBlock1);
+
+        store.put(storedBlock1);
+
+        try {
+            store.put(storedBlock1);
+            Assert.fail("Should throw BlockStoreException");
+        } catch (BlockStoreException e) {
+            Assert.assertEquals("A block with the same hash is already in the store", e.getMessage());
+        }
+
+        try {
+            store.put(updatedStoredBlock1);
+            Assert.fail("Should throw BlockStoreException");
+        } catch (BlockStoreException e) {
+            Assert.assertEquals("A block with the same hash is already in the store", e.getMessage());
+        }
+    }
+
     @Test
     public void chainHeadStoreTest() throws SQLException, IOException {
             byte[] raw = Base64.getDecoder().decode("AAATiAAClOfcPjviGpbszw+99fYqMzHcmVw2sJNWN4YGed3V2w8TUxKywnhnyag+8bmbmFyblJMHAjrWcrr9dw==");

--- a/core/src/test/java/org/veriblock/sdk/blockchain/store/VeriBlockStoreTest.java
+++ b/core/src/test/java/org/veriblock/sdk/blockchain/store/VeriBlockStoreTest.java
@@ -88,7 +88,8 @@ public class VeriBlockStoreTest {
             Assert.assertEquals(storedVeriBlockBlockExpected, storedVeriBlockBlockActual);
     }
 
-    public void PutDoesNotUpdateTest() throws SQLException, IOException {
+    @Test
+    public void putDoesNotUpdateTest() throws SQLException, IOException {
         StoredVeriBlockBlock updatedStoredBlock1 = new StoredVeriBlockBlock(block1, BigInteger.ONE);
         Assert.assertNotEquals(updatedStoredBlock1, storedBlock1);
 


### PR DESCRIPTION
… 