### PR TITLE
mock-pop-mining: fix VeriBlockBlockData to use getId() in Merkle path and root calculations; reimplement it to store regular and PoP VeriBlock transactions instead of blobs

### DIFF
--- a/mock-pop-mining/src/main/java/org/veriblock/sdk/mock/VeriBlockBlockData.java
+++ b/mock-pop-mining/src/main/java/org/veriblock/sdk/mock/VeriBlockBlockData.java
@@ -10,29 +10,90 @@ package org.veriblock.sdk.mock;
 
 import org.veriblock.sdk.models.Sha256Hash;
 import org.veriblock.sdk.models.VeriBlockMerklePath;
+import org.veriblock.sdk.models.VeriBlockPoPTransaction;
+import org.veriblock.sdk.models.VeriBlockTransaction;
+import org.veriblock.sdk.services.SerializeDeserializeService;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class VeriBlockBlockData {
 
-    List<byte[]> txs = new ArrayList<>();
-    List<byte[]> popTxs = new ArrayList<>();
+    private abstract class Subtree<T> extends ArrayList<T> {
+        abstract public Sha256Hash getSubject(int index);
+
+        public Sha256Hash getMerkleRoot() {
+            return calculateSubtreeHash(0, 0);
+        }
+
+        // calculate the number of bits it takes to store size()
+        private int getMaxDepth() {
+            return (int)(Math.log(size()) / Math.log(2) + 1);
+        }
+
+        // at each depth, there are 2**depth subtrees
+        // leaves are at the depth equal to getMaxDepth()
+        private Sha256Hash calculateSubtreeHash(int index, int depth) {
+            if (depth >= getMaxDepth()) {
+                return index < size() ? getSubject(index) : Sha256Hash.of(new byte[0]);
+            }
+
+            return Sha256Hash.of(calculateSubtreeHash(index * 2, depth + 1).getBytes(),
+                                 calculateSubtreeHash(index * 2 + 1, depth + 1).getBytes());
+        }
+
+        public List<Sha256Hash> getMerkleLayers(int index) {
+            if (index >= size())
+                throw new IndexOutOfBoundsException("index must be less than size()");
+
+            int maxDepth = getMaxDepth();
+            int layerIndex = index;
+
+            // 2 layers will be added by get*MerklePath()
+            List<Sha256Hash> layers = new ArrayList<>(maxDepth + 2);
+
+            for (int depth = maxDepth; depth > 0; depth--) {
+                // invert the last bit of layerIndex to reach the opposite subtree
+                Sha256Hash layer = calculateSubtreeHash(layerIndex ^ 1, depth);
+                layers.add(layer);
+
+                layerIndex /= 2;
+            }
+
+            return layers;
+        }
+
+    }
+
+    public class RegularSubtree extends Subtree<VeriBlockTransaction> {
+        public Sha256Hash getSubject(int index) {
+            return SerializeDeserializeService.getId(get(index));
+        }
+    }
+
+    public class PoPSubtree extends Subtree<VeriBlockPoPTransaction> {
+        public Sha256Hash getSubject(int index) {
+            return SerializeDeserializeService.getId(get(index));
+        }
+    }
+
+    RegularSubtree txs = new RegularSubtree();
+    PoPSubtree popTxs = new PoPSubtree();
 
     byte[] blockContentMetapackage = new byte[0];
 
     public Sha256Hash getMerkleRoot() {
         return Sha256Hash.of(
                     Sha256Hash.of(blockContentMetapackage).getBytes(),
-                    Sha256Hash.of(getMerkleRoot(txs).getBytes(),
-                                  getMerkleRoot(popTxs).getBytes()).getBytes());
+                    Sha256Hash.of(txs.getMerkleRoot().getBytes(),
+                                  popTxs.getMerkleRoot().getBytes()).getBytes());
     }
 
-    public List<byte[]> getRegularTransactions() {
+    public RegularSubtree getRegularTransactions() {
         return txs;
     }
 
-    public List<byte[]> getPoPTransactions() {
+    public PoPSubtree getPoPTransactions() {
         return popTxs;
     }
 
@@ -44,70 +105,30 @@ public class VeriBlockBlockData {
         return blockContentMetapackage;
     }
 
-    private VeriBlockMerklePath getMerklePath(int treeIndex, int index) {
-        assert(treeIndex == 0 || treeIndex == 1);
+    public VeriBlockMerklePath getRegularMerklePath(int index) {
+        Sha256Hash subject = txs.getSubject(index);
 
-        List<byte[]> transactions = treeIndex == 0 ? txs : popTxs;
-
-        Sha256Hash subject = Sha256Hash.of(transactions.get(index));
-
-        List<Sha256Hash> layers = getMerkleLayers(index, transactions);
+        List<Sha256Hash> layers = txs.getMerkleLayers(index);
 
         // the other transaction subtree
-        layers.add(getMerkleRoot(treeIndex == 1 ? txs : popTxs));
+        layers.add(popTxs.getMerkleRoot());
 
         layers.add(Sha256Hash.of(blockContentMetapackage));
 
-        return new VeriBlockMerklePath(treeIndex, index, subject, layers);
-    }
-
-    public VeriBlockMerklePath getRegularMerklePath(int index) {
-        return getMerklePath(0, index);
+        return new VeriBlockMerklePath(0, index, subject, layers);
     }
 
     public VeriBlockMerklePath getPoPMerklePath(int index) {
-        return getMerklePath(1, index);
-    }
+        Sha256Hash subject = popTxs.getSubject(index);
 
-    private Sha256Hash getMerkleRoot(List<byte[]> txs) {
-        return calculateSubtreeHash(0, 0, txs);
-    }
+        List<Sha256Hash> layers =  popTxs.getMerkleLayers(index);
 
-    // calculate the number of bits it takes to store size()
-    private int getMaxDepth(List<byte[]> txs) {
-        return (int)(Math.log(txs.size()) / Math.log(2) + 1);
-    }
+        // the other transaction subtree
+        layers.add(txs.getMerkleRoot());
 
-    // at each depth, there are 2**depth subtrees
-    // leaves are at the depth equal to getMaxDepth()
-    private Sha256Hash calculateSubtreeHash(int index, int depth, List<byte[]> txs) {
-        if (depth >= getMaxDepth(txs)) {
-            return Sha256Hash.of(index < txs.size() ? txs.get(index) : new byte[0]);
-        }
+        layers.add(Sha256Hash.of(blockContentMetapackage));
 
-        return Sha256Hash.of(calculateSubtreeHash(index * 2, depth + 1, txs).getBytes(),
-                             calculateSubtreeHash(index * 2 + 1, depth + 1, txs).getBytes());
-    }
-
-    private List<Sha256Hash> getMerkleLayers(int index, List<byte[]> txs) {
-        if (index >= txs.size())
-            throw new IndexOutOfBoundsException("index must be less than size()");
-
-        int maxDepth = getMaxDepth(txs);
-        int layerIndex = index;
-
-        // 2 layers will be added by get*MerklePath()
-        List<Sha256Hash> layers = new ArrayList<>(maxDepth + 2);
-
-        for (int depth = maxDepth; depth > 0; depth--) {
-            // invert the last bit of layerIndex to reach the opposite subtree
-            Sha256Hash layer = calculateSubtreeHash(layerIndex ^ 1, depth, txs);
-            layers.add(layer);
-
-            layerIndex /= 2;
-        }
-
-        return layers;
+        return new VeriBlockMerklePath(1, index, subject, layers);
     }
 
 }

--- a/mock-pop-mining/src/test/java/org/veriblock/sdk/mock/VeriBlockBlockDataTest.java
+++ b/mock-pop-mining/src/test/java/org/veriblock/sdk/mock/VeriBlockBlockDataTest.java
@@ -8,16 +8,32 @@
 
 package org.veriblock.sdk.mock;
 
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.List;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.veriblock.sdk.models.Address;
+import org.veriblock.sdk.models.BitcoinBlock;
+import org.veriblock.sdk.models.BitcoinTransaction;
+import org.veriblock.sdk.models.Coin;
+import org.veriblock.sdk.models.Constants;
+import org.veriblock.sdk.models.MerklePath;
+import org.veriblock.sdk.models.Output;
+import org.veriblock.sdk.models.PublicationData;
 import org.veriblock.sdk.models.Sha256Hash;
+import org.veriblock.sdk.models.VeriBlockBlock;
 import org.veriblock.sdk.models.VeriBlockMerklePath;
+import org.veriblock.sdk.models.VeriBlockPoPTransaction;
+import org.veriblock.sdk.models.VeriBlockTransaction;
+import org.veriblock.sdk.services.SerializeDeserializeService;
+import org.veriblock.sdk.util.Base58;
 import org.veriblock.sdk.util.MerklePathUtil;
-
-import java.util.Random;
 
 public class VeriBlockBlockDataTest {
 
@@ -28,7 +44,7 @@ public class VeriBlockBlockDataTest {
             VeriBlockMerklePath merklePath = blockData.getRegularMerklePath(index);
 
             Assert.assertEquals(merklePath.getSubject(),
-                                Sha256Hash.of(blockData.getRegularTransactions().get(index)));
+                                blockData.getRegularTransactions().getSubject(index));
         
             Assert.assertEquals(merkleRoot,
                                 MerklePathUtil.calculateVeriMerkleRoot(merklePath));
@@ -44,7 +60,7 @@ public class VeriBlockBlockDataTest {
             VeriBlockMerklePath merklePath = blockData.getPoPMerklePath(index);
 
             Assert.assertEquals(merklePath.getSubject(),
-                                Sha256Hash.of(blockData.getPoPTransactions().get(index)));
+                                blockData.getPoPTransactions().getSubject(index));
         
             Assert.assertEquals(merkleRoot,
                                 MerklePathUtil.calculateVeriMerkleRoot(merklePath));
@@ -57,19 +73,117 @@ public class VeriBlockBlockDataTest {
         }
     }
 
-    private VeriBlockBlockData createBlockData(Random random, int regularCount, int popCount, int maxSize) {
+    private byte[] randomBytes(Random random, int count) {
+        byte[] data = new byte[count];
+        random.nextBytes(data);
+        return data;
+    }
+
+    private Sha256Hash randomSha256Hash(Random random) {
+        return Sha256Hash.wrap(randomBytes(random, Sha256Hash.BITCOIN_LENGTH));
+    }
+
+    private Address randomAddress(Random random) {
+        Sha256Hash hash = randomSha256Hash(random);
+        String data = "V" + Base58.encode(hash.getBytes()).substring(0, 24);
+
+        Sha256Hash dataHash = Sha256Hash.of(data.getBytes(StandardCharsets.UTF_8));
+        String checksum = Base58.encode(dataHash.getBytes()).substring(0, 4 + 1);
+
+        return new Address(data + checksum);
+    }
+
+    private BitcoinBlock randomBitcoinBlock(Random random) {
+        return SerializeDeserializeService.parseBitcoinBlock(randomBytes(random, Constants.HEADER_SIZE_BitcoinBlock));
+    }
+
+    private VeriBlockBlock randomVeriBlockBlock(Random random) {
+        return SerializeDeserializeService.parseVeriBlockBlock(randomBytes(random, Constants.HEADER_SIZE_VeriBlockBlock));
+    }
+
+    private BitcoinTransaction randomBitcoinTransaction(Random random) {
+        return new BitcoinTransaction(randomBytes(random, 100));
+    }
+
+    private MerklePath randomMerklePath(Random random, int maxIndex) {
+        int index = random.nextInt(maxIndex);
+
+        int layerCount = (int)(Math.log(maxIndex) / Math.log(2) + 1);
+
+        List<Sha256Hash> layers = new ArrayList<>(layerCount);
+        for (int i = 0; i < layerCount; i++) {
+            layers.add(randomSha256Hash(random));
+        }
+
+        return new MerklePath(index, randomSha256Hash(random), layers);
+    }
+
+    private List<BitcoinBlock> randomBitcoinContext(Random random, int maxSize) {
+        int size = random.nextInt(maxSize);
+        List<BitcoinBlock> context = new ArrayList<>(size);
+
+        for (int i = 0; i < size; i++) {
+            context.add(randomBitcoinBlock(random));
+        }
+
+        return context;
+    }
+
+    private Coin randomCoin(Random random, int maxUnits) {
+        return Coin.valueOf(random.nextInt(maxUnits));
+    }
+
+    private Output randomOutput(Random random, int maxUnits) {
+        return new Output(randomAddress(random), randomCoin(random, maxUnits));
+    }
+
+    private List<Output> randomOutputs(Random random, int maxOutputs, int maxUnits) {
+        int size = random.nextInt(maxOutputs);
+
+        List<Output> outputs = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            outputs.add(randomOutput(random, maxUnits));
+        }
+
+        return outputs;
+    }
+
+    private PublicationData randomPublicationData(Random random) {
+        return new PublicationData(random.nextInt(1000000),
+                                   randomBytes(random, 16),
+                                   randomBytes(random, 32),
+                                   randomBytes(random, 64));
+    };
+
+    private VeriBlockBlockData createBlockData(Random random, int regularCount, int popCount) {
         VeriBlockBlockData blockData = new VeriBlockBlockData();
 
         for (int i = 0; i < regularCount; i++) {
-            byte[] data = new byte[random.nextInt(maxSize)];
-            random.nextBytes(data);
-            blockData.getRegularTransactions().add(data);
+            VeriBlockTransaction tx = new VeriBlockTransaction(
+                                            (byte)1,
+                                            randomAddress(random),
+                                            randomCoin(random, 1000000),
+                                            randomOutputs(random, 10, 100000),
+                                            7,
+                                            randomPublicationData(random),
+                                            randomBytes(random, 40),
+                                            randomBytes(random, 40),
+                                            (byte)0xAA);
+            blockData.getRegularTransactions().add(tx);
         }
 
         for (int i = 0; i < popCount; i++) {
-            byte[] data = new byte[random.nextInt(maxSize)];
-            random.nextBytes(data);
-            blockData.getPoPTransactions().add(data);
+            VeriBlockPoPTransaction tx = new VeriBlockPoPTransaction(
+                                            randomAddress(random),
+                                            randomVeriBlockBlock(random),
+                                            randomBitcoinTransaction(random),
+                                            randomMerklePath(random, 256),
+                                            randomBitcoinBlock(random),
+                                            randomBitcoinContext(random, 16),
+                                            randomBytes(random, 40),
+                                            randomBytes(random, 40),
+                                            (byte)0xAA);
+            blockData.getPoPTransactions().add(tx);
         }
 
         return blockData;
@@ -85,7 +199,7 @@ public class VeriBlockBlockDataTest {
     @Test
     public void singleItemTest() {
         Random random = new Random(0); // make the test repeatable
-        VeriBlockBlockData blockData = createBlockData(random, 1, 1, 16);
+        VeriBlockBlockData blockData = createBlockData(random, 1, 1);
 
         checkBlockData(blockData);
     }
@@ -93,7 +207,7 @@ public class VeriBlockBlockDataTest {
     @Test
     public void multiItemTest() {
         Random random = new Random(0); // make the test repeatable
-        VeriBlockBlockData blockData = createBlockData(random, 5, 5, 128);
+        VeriBlockBlockData blockData = createBlockData(random, 5, 8);
 
         checkBlockData(blockData);
     }


### PR DESCRIPTION
… 